### PR TITLE
Add Claude Code command definitions and tool mapping guide

### DIFF
--- a/.claude/commands/analyze-ticket.md
+++ b/.claude/commands/analyze-ticket.md
@@ -1,0 +1,25 @@
+# Analyze Ticket
+
+Validate a ticket-level plan file to ensure completeness, coverage, and proper structure.
+
+## Input
+
+Ticket identifier: $ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/analyze-ticket.prompt.md`
+2. Follow agent guidelines in `AGENTS.md`
+3. Read shared includes as referenced by the prompt:
+   - `.github/prompts/includes/ticket-detection.md` for platform detection
+4. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+5. Execute all 13 steps as defined in the prompt file
+6. Produce a structured analysis report (read-only; do not modify files without explicit user approval)
+
+## Key Behavioral Rules (from prompt file)
+
+- STRICTLY READ-ONLY: Do not modify any files without explicit user approval
+- NEVER hallucinate missing sections; state "section missing" if absent
+- Make findings deterministic with stable IDs
+- Severity: CRITICAL > HIGH > MEDIUM > LOW
+- Only edit plan files (`docs/plan/tickets/*-plan.md`) if user explicitly requests it

--- a/.claude/commands/cut-pr.md
+++ b/.claude/commands/cut-pr.md
@@ -1,0 +1,26 @@
+# Cut PR
+
+Create a pull request from the current branch to the default branch with automatic title and description generation.
+
+## Input
+
+$ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/cut-pr.prompt.md`
+2. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+3. Use `gh pr create` for PR creation (replaces MCP `github/create_pull_request`)
+4. Execute all 4 phases as defined in the prompt file:
+   - Phase 0: Pre-flight checks (uncommitted changes, unpushed commits, merge conflicts)
+   - Phase 1: Gather repository context (PR template, ticket auto-detection, change analysis)
+   - Phase 2: Generate PR content (semantic title, structured description)
+   - Phase 3: Create the PR via `gh pr create`
+
+## Key Behavioral Rules (from prompt file)
+
+- Abort immediately if pre-flight checks fail, with clear error message
+- Auto-detect ticket ID from branch name if not provided
+- Use semantic commit-style PR titles: `<type>(<scope>): #<TICKET_ID> <summary>`
+- Use repository PR template if one exists; otherwise use best-practices structure
+- No user confirmation required for PR creation (auto-create after validation)

--- a/.claude/commands/find-next-ticket.md
+++ b/.claude/commands/find-next-ticket.md
@@ -1,0 +1,23 @@
+# Find Next Ticket
+
+Identify the single next executable GitHub issue based on dependency ordering, priority, and milestone.
+
+## Input
+
+$ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/find-next-ticket.prompt.md`
+2. Apply behavioral guardrails from `.github/agents/find-next-ticket.agent.md`
+3. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+4. Use `gh` CLI for all GitHub issue queries (replaces MCP `gh-issues/*` tools)
+5. Execute the selection algorithm as defined in the prompt file
+
+## Key Behavioral Rules (from agent file)
+
+- Read-only mode: NEVER modify issues, add comments, or transition statuses
+- Output ONLY `#<number>` if a startable issue exists, nothing else
+- If no startable issue: output concise blocker explanation
+- Treat only explicit "blocks" link relationships as dependencies
+- A predecessor is satisfied ONLY if state == closed

--- a/.claude/commands/plan-ticket.md
+++ b/.claude/commands/plan-ticket.md
@@ -1,0 +1,29 @@
+# Plan Ticket
+
+Build an execution-ready implementation plan for a GitHub issue using TDD and repo context.
+
+## Input
+
+Ticket identifier: $ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/plan-ticket.prompt.md`
+2. Apply behavioral guardrails from `.github/agents/plan-ticket.agent.md`
+3. Read shared includes as referenced by the prompt:
+   - `.github/prompts/includes/ticket-detection.md` for platform detection
+   - `.github/prompts/includes/branch-commit-guidance.md` for git conventions
+   - `.github/prompts/includes/signed-commits-requirement.md` for commit signing
+   - `.github/agents/includes/tdd-enforcement-cycle.md` for TDD cycle
+4. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+5. Execute all steps (0 through 4) as defined in the prompt file
+6. Output all 11 required sections and persist to `docs/plan/tickets/{{TICKET_ID}}-plan.md`
+
+## Key Behavioral Rules (from agent file)
+
+- No production code authored; planning only
+- Search for reusable patterns before proposing new utilities
+- Cite file paths for every reused pattern
+- Flag all blockers for user clarification
+- Evaluate scope decomposition for every ticket
+- Await user approval before creating sub-issues

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,27 @@
+# Review Pull Request
+
+Review a pull request against GitHub issue acceptance criteria with focus on code quality.
+
+## Input
+
+Ticket identifier and PR reference: $ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/review-pr.prompt.md`
+2. Apply behavioral guardrails from `.github/agents/code-review.agent.md`
+3. Read shared includes as referenced by the prompt:
+   - `.github/prompts/includes/ticket-detection.md` for platform detection
+4. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+5. Use `gh pr view` and `gh pr diff` for PR details (replaces MCP `github/pull_request_read`)
+6. Execute all 9 steps as defined in the prompt file
+7. Produce the review summary using the template in the prompt file
+
+## Key Behavioral Rules (from agent file)
+
+- Focus on code under review, not tangential improvements
+- Distinguish "must fix" (blocking) from "nice to have" (suggestion)
+- Base feedback on established principles, not personal preference
+- Assume positive intent from code authors
+- No automatic code modifications (review only)
+- Severity levels: Blocking > Warning > Suggestion > Praise

--- a/.claude/commands/review-ticket-work.md
+++ b/.claude/commands/review-ticket-work.md
@@ -1,0 +1,25 @@
+# Review Ticket Work
+
+Review local changes against a GitHub issue's acceptance criteria before pushing to remote.
+
+## Input
+
+Ticket identifier: $ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/review-ticket-work.prompt.md`
+2. Apply behavioral guardrails from `.github/agents/code-review.agent.md`
+3. Read shared includes as referenced by the prompt:
+   - `.github/prompts/includes/ticket-detection.md` for platform detection
+4. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+5. Execute all 7 steps as defined in the prompt file
+6. Produce the review summary using the template in the prompt file
+
+## Key Behavioral Rules (from prompt file)
+
+- Map every acceptance criterion to implementation evidence
+- Check for duplication, complexity, and business logic clarity
+- Run all quality gates (tests, linting, coverage)
+- Flag for human review if ACs cannot be verified or security issues detected
+- Output recommendation: Ready to push / Ready with improvements / Blocked

--- a/.claude/commands/sync-agent-templates.md
+++ b/.claude/commands/sync-agent-templates.md
@@ -1,0 +1,29 @@
+# Sync Agent Templates
+
+Synchronize `.github` folder contents from the agent-templates repository into the current repository.
+
+## Input
+
+$ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/sync-agent-templates.prompt.md`
+2. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+3. Execute all 8 phases as defined in the prompt file:
+   - Phase 0: Workspace validation
+   - Phase 1: Clone agent-templates to temp directory
+   - Phase 2: Discover template files
+   - Phase 3: Categorize as new or conflicting
+   - Phase 4: Auto-copy new files
+   - Phase 5: Present conflicts for user resolution
+   - Phase 6: Execute chosen resolution strategy
+   - Phase 7: Cleanup temporary clone
+
+## Key Behavioral Rules (from prompt file)
+
+- Never overwrite or delete base repo files without user approval (except auto-copy of new files)
+- Always cleanup temporary directory on success or error
+- Provide clear progress updates after each phase
+- Default to "overwrite none" if user does not respond to conflict resolution
+- See `.github/prompts/__tests__/sync-agent-templates.test.md` for test scenarios

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -1,0 +1,27 @@
+# Work Ticket
+
+Execute an approved implementation plan for a GitHub issue using strict TDD, quality gates, and issue synchronization.
+
+## Input
+
+Ticket identifier: $ARGUMENTS
+
+## Instructions
+
+1. Read and follow the full workflow in `.github/prompts/work-ticket.prompt.md`
+2. Apply behavioral guardrails from `.github/agents/work-ticket.agent.md`
+3. Read shared includes as referenced by the prompt:
+   - `.github/prompts/includes/ticket-detection.md` for platform detection
+   - `.github/prompts/includes/branch-commit-guidance.md` for git conventions
+   - `.github/prompts/includes/signed-commits-requirement.md` for commit signing
+   - `.github/agents/includes/tdd-enforcement-cycle.md` for TDD cycle
+4. Use the tool mapping in `CLAUDE.md` to translate MCP tool references to Claude Code equivalents
+5. Execute all phases (0 through 9) as defined in the prompt file
+
+## Key Behavioral Rules (from agent file)
+
+- TDD is non-negotiable: RED → GREEN → REFACTOR
+- No production logic without corresponding tests
+- Quality gates must all pass before completion
+- No scope expansion beyond the plan
+- No automatic git commits without user confirmation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# Claude Code Project Instructions
+
+## Mandatory Guidelines
+
+Read and follow `AGENTS.md` for all work. Its MUST rules override any conflicting guidance.
+
+Key mandates from `AGENTS.md`:
+
+- **Quality First:** All work must meet acceptance criteria, include tests, and pass linting
+- **TDD Enforcement:** RED → GREEN → REFACTOR. Tests before production logic
+- **Accuracy:** Do not guess. Verify with repo sources or explicit user input
+- **No Silent Assumptions:** Document assumptions and open questions explicitly
+
+## Workflow
+
+Follow the end-to-end ticket workflow defined in `TICKET_FLOW.md`:
+
+```
+find-next-ticket → plan-ticket → analyze-ticket → work-ticket → review-ticket-work → cut-pr → review-pr
+```
+
+For larger initiatives spanning multiple teams, follow `SDLC_INITIATIVE_PLANNING.md`.
+
+## Available Commands
+
+These slash commands map to the GitHub Copilot prompts and agents defined in `.github/prompts/` and `.github/agents/`. Each command references those files directly to avoid duplication.
+
+| Command | Copilot Prompt | Copilot Agent | Purpose |
+|---------|---------------|---------------|---------|
+| `/project:find-next-ticket` | `.github/prompts/find-next-ticket.prompt.md` | `.github/agents/find-next-ticket.agent.md` | Select next executable GitHub issue |
+| `/project:plan-ticket` | `.github/prompts/plan-ticket.prompt.md` | `.github/agents/plan-ticket.agent.md` | Create TDD implementation plan |
+| `/project:analyze-ticket` | `.github/prompts/analyze-ticket.prompt.md` | - | Validate a ticket plan for gaps |
+| `/project:work-ticket` | `.github/prompts/work-ticket.prompt.md` | `.github/agents/work-ticket.agent.md` | Execute plan with TDD + quality gates |
+| `/project:review-ticket-work` | `.github/prompts/review-ticket-work.prompt.md` | - | Review local changes before push |
+| `/project:review-pr` | `.github/prompts/review-pr.prompt.md` | `.github/agents/code-review.agent.md` | Review a pull request |
+| `/project:cut-pr` | `.github/prompts/cut-pr.prompt.md` | - | Create PR from current branch |
+| `/project:sync-agent-templates` | `.github/prompts/sync-agent-templates.prompt.md` | - | Sync .github/ from agent-templates repo |
+
+## Tool Mapping: Copilot MCP → Claude Code
+
+The Copilot prompts and agents reference MCP tools. When executing those workflows in Claude Code, use these native equivalents:
+
+### File Operations
+
+| Copilot MCP Tool | Claude Code Equivalent |
+|---|---|
+| `desktop-commander/read_file` | `Read` tool |
+| `desktop-commander/edit_block` | `Edit` tool |
+| `desktop-commander/write_file` | `Write` tool |
+| `desktop-commander/create_directory` | `Bash` (`mkdir -p`) |
+| `desktop-commander/list_directory` | `Glob` tool or `Bash` (`ls`) |
+| `desktop-commander/move_file` | `Bash` (`mv`) |
+| `github/get_file_contents` | `Read` tool (local) or `Bash` (`gh api`) |
+| `github/create_or_update_file` | `Edit`/`Write` tool + `Bash` (`git commit`) |
+
+### Search & Discovery
+
+| Copilot MCP Tool | Claude Code Equivalent |
+|---|---|
+| `desktop-commander/start_search` (files) | `Glob` tool |
+| `desktop-commander/start_search` (content) | `Grep` tool |
+| `deepcontext/search_codebase` | `Task` tool (Explore agent) |
+
+### GitHub & Issue Tracking
+
+| Copilot MCP Tool | Claude Code Equivalent |
+|---|---|
+| `github/create_pull_request` | `Bash` (`gh pr create`) |
+| `github/create_branch` | `Bash` (`git switch -c`) |
+| `github/list_branches` | `Bash` (`git branch` / `gh api`) |
+| `github/list_commits` | `Bash` (`git log`) |
+| `github/push_files` | `Bash` (`git add` + `git commit` + `git push`) |
+| `github/search_code` | `Grep` tool or `Bash` (`gh search code`) |
+| `github/search_issues` | `Bash` (`gh search issues`) |
+| `gh-issues/issue_read` | `Bash` (`gh issue view`) |
+| `gh-issues/issue_write` | `Bash` (`gh issue edit` / `gh issue create`) |
+| `gh-issues/add_issue_comment` | `Bash` (`gh issue comment`) |
+| `gh-issues/search_issues` | `Bash` (`gh search issues`) |
+| `gh-actions/*` | `Bash` (`gh run list` / `gh run view`) |
+
+### Testing & Quality
+
+| Copilot MCP Tool | Claude Code Equivalent |
+|---|---|
+| `run_in_terminal` | `Bash` tool |
+| `execute/runTests` | `Bash` (`npm test` or project test command) |
+| `markdownlint/*` | `Bash` (`npx markdownlint-cli2`) |
+| `codacy-mcp-server/*` | `Bash` (Codacy CLI or CI results) |
+| `playwright/*` | `Bash` (`npx playwright test`) |
+
+### Reasoning & Planning
+
+| Copilot MCP Tool | Claude Code Equivalent |
+|---|---|
+| `sequentialthinking/*` | Built-in reasoning (native to Claude) |
+| `agent` (sub-agent delegation) | `Task` tool |
+
+## Shared Includes
+
+These files contain shared guidance referenced by multiple prompts and agents. Read them when the prompt or agent file directs you to:
+
+- `.github/prompts/includes/mcp-tooling-requirements.md` — Tool usage mandate (use tool mapping above for Claude Code equivalents)
+- `.github/prompts/includes/ticket-detection.md` — GitHub/Jira platform auto-detection
+- `.github/prompts/includes/branch-commit-guidance.md` — Branch naming and commit conventions
+- `.github/prompts/includes/signed-commits-requirement.md` — GPG/SSH commit signing toggle
+- `.github/prompts/includes/mode-enforcement.md` — Mode requirement template
+- `.github/prompts/includes/ac-validation-template.md` — Acceptance criteria table template
+- `.github/prompts/includes/issue-severity-scale.md` — Severity classification scale
+- `.github/prompts/includes/pre-commit-quality-review.md` — Pre-commit quality checklist
+- `.github/agents/includes/tdd-enforcement-cycle.md` — RED/GREEN/REFACTOR cycle
+
+## Instructions
+
+- `.github/instructions/codacy.instructions.md` — Codacy code quality tool configuration
+- `.github/instructions/markdown.instructions.md` — Markdown linting rules
+
+## Adapting MCP Tool References
+
+When a Copilot prompt says "use MCP tool X", substitute the Claude Code equivalent from the mapping table above. The workflow logic, phases, quality gates, and behavioral guardrails remain identical — only the tool invocations change.
+
+When a prompt references `.github/prompts/includes/mcp-tooling-requirements.md`, apply its principles (prefer structured tools over raw shell commands) using Claude Code's native tools: `Read`, `Edit`, `Write`, `Glob`, `Grep`, and `Bash` for git/gh CLI operations.


### PR DESCRIPTION
## Summary

This PR establishes the foundational command structure and tool mapping documentation for executing the GitHub Copilot agent workflows within Claude Code. It adds eight new command definition files and a comprehensive tool mapping guide that bridges MCP tool references to Claude Code native equivalents.

## Key Changes

- **Command Definitions** (`.claude/commands/`): Added 8 command files that define the workflow for each stage of the ticket lifecycle:
  - `find-next-ticket.md` — Select next executable GitHub issue
  - `plan-ticket.md` — Create TDD implementation plan
  - `analyze-ticket.md` — Validate ticket plan for gaps
  - `work-ticket.md` — Execute plan with TDD + quality gates
  - `review-ticket-work.md` — Review local changes before push
  - `review-pr.md` — Review a pull request
  - `cut-pr.md` — Create PR from current branch
  - `sync-agent-templates.md` — Sync `.github/` from agent-templates repo

- **Tool Mapping Guide** (`CLAUDE.md`): Comprehensive reference document that:
  - Maps Copilot MCP tools to Claude Code native equivalents (Read, Write, Edit, Glob, Grep, Bash)
  - Documents the complete ticket workflow and available commands
  - References shared includes and behavioral guardrails
  - Provides guidance for adapting MCP tool references to Claude Code

## Implementation Details

- Each command file follows a consistent structure: Input specification, Instructions (referencing corresponding `.github/prompts/` and `.github/agents/` files), and Key Behavioral Rules
- Tool mapping covers file operations, search & discovery, GitHub/issue tracking, testing & quality, and reasoning
- All commands reference existing Copilot prompt and agent files to avoid duplication and maintain single source of truth
- Commands are designed to be read-only by default with explicit user approval gates for modifications

https://claude.ai/code/session_018HMa1xCq5cVHdw7veNpNQQ